### PR TITLE
Map on node pages

### DIFF
--- a/docroot/themes/custom/mappy/sass/components/_map-overrides.scss
+++ b/docroot/themes/custom/mappy/sass/components/_map-overrides.scss
@@ -58,7 +58,7 @@
 
 // On mobile, move zoom controls up so sidebar content doesn't cover it.
 @media only screen and (max-width: 851px) {
-  .leaflet-bottom {
+  .path-frontpage .leaflet-bottom {
     bottom: 15vh;
   }
 }

--- a/docroot/themes/custom/mappy/sass/layouts/_nodepage.scss
+++ b/docroot/themes/custom/mappy/sass/layouts/_nodepage.scss
@@ -79,8 +79,9 @@
     .map--node {
       @include box-shadow;
 
-      width: 100%;
       height: 300px;
+      margin-top: $general-spacing;
+      width: 100%;
     }
 
   }


### PR DESCRIPTION
@timstallmann two small changes to improve the way things look on small screens:
1. Add some space above map
2. The front page map controls need to move on small screens, but this shouldn't happen on node pages.

Looks awesome!! So glad we're getting this merged in.
